### PR TITLE
Fix defect when other plugins add a GrailsSpecTestType.

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -33,6 +33,9 @@ grails.project.dependency.resolution = {
 
     plugins {
         build ":release:2.0.2", {export = false}
+        test(":spock:0.7") {
+          exclude "spock-grails-support"
+        }
     }
 
     dependencies {

--- a/src/groovy/grails/plugin/functional/spock/SpecTestTypeLoader.groovy
+++ b/src/groovy/grails/plugin/functional/spock/SpecTestTypeLoader.groovy
@@ -38,7 +38,7 @@ class SpecTestTypeLoader {
     }
 
     boolean isShouldRegisterSpecSupport() {
-        return !variables.functionalTests.any {it in specType}
+        return !variables.functionalTests.any {(it in specType) && it.name == 'spock' && it.relativeSourcePath == 'functional'}
     }
 
     private addFunctionalSpecSupport() {

--- a/test/unit/grails/plugin/functional/spock/SpecTestTypeLoaderSpec.groovy
+++ b/test/unit/grails/plugin/functional/spock/SpecTestTypeLoaderSpec.groovy
@@ -48,6 +48,10 @@ class SpecTestTypeLoaderSpec extends Specification {
         binding.variables.functionalTests.find {it in GrailsSpecTestType}
     }
 
+    private boolean testTypeRegistered(String name, String relativeSourcePath) {
+        binding.variables.functionalTests.any {(it in GrailsSpecTestType) && it.name == name && it.relativeSourcePath == relativeSourcePath}
+    }
+
     def "if type already registered skip"() {
         given:
         binding.variables = [functionalTests: []]
@@ -58,6 +62,18 @@ class SpecTestTypeLoaderSpec extends Specification {
 
         then:
         functionalTestTypes.size() == 1
+    }
+
+    def "when functional tests define a spec type but not for functional spock"() {
+        given:
+        binding.variables = [functionalTests:[new GrailsSpecTestType('spock-somethingelse','somethingelse')]]
+
+        when:
+        loader.registerFunctionalSpecSupport()
+
+        then:
+        functionalTestTypes.size() == 2
+        testTypeRegistered('spock','functional') == true
     }
 
     private List getFunctionalTestTypes() {


### PR DESCRIPTION
The plugin previously decided whether it needed to add a spock
functional test type by seeing if functionalTests contained
any instances of GrailsSpecTestType.  This can cause a
functional spock type to not be added when other plugins,
e.g. selenium, also add a GrailsSpecTestType.

By changing the check to also consider the name and
relativeSourcePath, the spock type gets added for
functional tests, even when selenium is also present.
